### PR TITLE
Add functions to count # of shared wallets and # of individual accounts

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -8,7 +8,7 @@ const PAGINATION_SIZE = 1000;
 
 const configuration = {
   endpoint:
-    'https://api.thegraph.com/subgraphs/name/circlesubi/circles',
+    'https://api.thegraph.com/subgraphs/name/azf20/circles-ubi',
   relayerAddress: '0x0739a8D036c966aC9161Ea14855CE0f94C15B87b',
   format: 'csv',
   log: undefined,

--- a/lib.js
+++ b/lib.js
@@ -8,7 +8,7 @@ const PAGINATION_SIZE = 1000;
 
 const configuration = {
   endpoint:
-    'https://graph.circles.garden/subgraphs/name/CirclesUBI/circles-subgraph',
+    'https://api.thegraph.com/subgraphs/name/circlesubi/circles',
   relayerAddress: '0x0739a8D036c966aC9161Ea14855CE0f94C15B87b',
   format: 'csv',
   log: undefined,
@@ -96,14 +96,16 @@ async function fetchAllFromGraph(name, fields, extra = '') {
   print(`Request all "${name}" data from Graph ...`);
 
   for await (let data of fetchGraphGenerator(name, fields, extra)) {
-    result = result.concat(
-      data.map((entry) => {
-        entry.index = ++index;
-        return entry;
-      }),
-    );
+    if (data.length > 0){
+      result = result.concat(
+        data.map((entry) => {
+          entry.index = ++index;
+          return entry;
+        }),
+      );
+    }
+      
   }
-
   return result;
 }
 
@@ -315,6 +317,32 @@ const analyses = {
         };
       });
 
+      return safesFormatted;
+    },
+  },
+  walletDeployedSafes: {
+    description: 'safe deployments that are shared wallets',
+    command: async () => {
+      const safes = await fetchAllFromGraph('safes', 'id', 'where: {deployed: true, organization: true}');
+      print('Deployed Safes that are Shared Wallets', safes.length);
+      const safesFormatted = safes.map((safe, index) => {
+        return {
+          index: index + 1,
+        };
+      });
+      return safesFormatted;
+    },
+  },
+  userDeployedSafes:{
+    description: 'safe deployments that are not shared wallets',
+    command: async () => {
+      const safes = await fetchAllFromGraph('safes', 'id', 'where: {deployed: true, organization: false}');
+      print('Deployed Safes that are Individual accounts', safes.length);
+      const safesFormatted = safes.map((safe, index) => {
+        return {
+          index: index + 1,
+        };
+      });
       return safesFormatted;
     },
   },

--- a/lib.js
+++ b/lib.js
@@ -62,7 +62,7 @@ async function fetchFromGraph(
       ${fields}
     }
   }`;
-
+  console.log(query.replace(/\s\s+/g, ' '));
   const data = await request(
     configuration.endpoint,
     query.replace(/\s\s+/g, ' '),
@@ -86,9 +86,9 @@ async function* fetchGraphGenerator(name, fields, where = '') {
       }})...`,
     );
     hasData = data.length > 0;
-    if (hasData) 
+    if (hasData) {
       lastID = data[data.length - 1].id;
-    
+    }
     skip += PAGINATION_SIZE;
     yield data;
   }
@@ -154,7 +154,7 @@ const analyses = {
     command: async () => {
       const notifications = await fetchAllFromGraph(
         'notifications',
-        'time hubTransfer { id from to amount }',
+        'id time hubTransfer { id from to amount }',
         'type: HUB_TRANSFER',
       );
 
@@ -222,7 +222,7 @@ const analyses = {
     command: async () => {
       const notifications = await fetchAllFromGraph(
         'notifications',
-        'time trust { id canSendTo user limitPercentage }',
+        'id time trust { id canSendTo user limitPercentage }',
         'type: TRUST',
       );
 


### PR DESCRIPTION
Fixed:
- The Graph correct endpoint.
- The `skip` argument in graph queries must be between 0 and 5000 (current limitations by TheGraph). Therefore, we sort the elements by id and reference the last element id for the next query.
- Use the `extra` field as `where` in graph queries.